### PR TITLE
回答例サンプル

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -94,6 +94,7 @@ def placeable?(board, attack_stone_color)
       return true if put_stone!(board, position.to_cellstr, attack_stone_color, false)
     end
   end
+  false
 end
 
 def count_stone(board, stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -70,6 +70,7 @@ end
 def turn!(board, target_pos, attack_stone_color, direction)
   return false if target_pos.out_of_board?
   return false if target_pos.stone_color(board) == attack_stone_color
+  return false if target_pos.stone_color(board) == BLANK_CELL
 
   next_pos = target_pos.next_position(direction)
   if (next_pos.stone_color(board) == attack_stone_color) || turn!(board, next_pos, attack_stone_color, direction)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -53,7 +53,7 @@ def put_stone!(board, cellstr, stone_color, execute = true) # rubocop:disable St
 
   # コピーした盤面にて石の配置を試みて、成功すれば反映する
   copied_board = Marshal.load(Marshal.dump(board))
-  copied_board[pos.row][pos.col] = stone_color
+  copied_board[pos.col][pos.row] = stone_color
 
   turn_succeed = false
   DIRECTIONS.each do |direction|


### PR DESCRIPTION
テストが落ちる要因を解決しました。

- 二次元配列のインデックスの定義が逆
- 空のセルはひっくり返すことができないルールを追加実装
- 配置可能判定メソッドで明確にfalseを返していなかった