### PR TITLE
Apply rubocop: Lint/RedundantStringCoercion

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -26,7 +26,7 @@ DIRECTIONS = [
 def output(board)
   puts "  #{ROW.join(' ')}"
   board.each.with_index do |row, i|
-    print COL[i].to_s
+    print COL[i]
     row.each do |cell|
       case cell
       when WHITE_STONE then print ' ○'


### PR DESCRIPTION
Rubocop指摘より、 `.to_s` は不要