### PR TITLE
fix COL index names

### DIFF
--- a/lib/position.rb
+++ b/lib/position.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class Position
-  # チェスボードを参考として、マスを 'a8', 'd6' と書いて表現する。
-  # 変数名cell_refとして取り扱う。
+  # マスを'f3','d6'などの表記で表現する。変数名cell_refとして取り扱う。
   ROW = %w[a b c d e f g h].freeze
-  COL = %w[8 7 6 5 4 3 2 1].freeze
+  COL = %w[1 2 3 4 5 6 7 8].freeze
 
   DIRECTIONS = [
     TOP_LEFT      = :top_left,

--- a/test/test.rb
+++ b/test/test.rb
@@ -43,7 +43,7 @@ class TestReversi < Minitest::Test
 
   def test_put_stone
     board = initial_board
-    assert put_stone!(board, 'e3', BLACK_STONE)
+    assert put_stone!(board, 'e6', BLACK_STONE)
     assert_equal build_board(<<~BOARD), board
       00000000
       00000000
@@ -54,7 +54,7 @@ class TestReversi < Minitest::Test
       00000000
       00000000
     BOARD
-    assert put_stone!(board, 'f5', WHITE_STONE)
+    assert put_stone!(board, 'f4', WHITE_STONE)
     assert_equal build_board(<<~BOARD), board
       00000000
       00000000
@@ -79,7 +79,7 @@ class TestReversi < Minitest::Test
       00200000
     BOARD
     board = build_board(initial_data)
-    refute put_stone!(board, 'b8', BLACK_STONE)
+    refute put_stone!(board, 'b1', BLACK_STONE)
     assert_equal build_board(initial_data), board
   end
 
@@ -94,7 +94,7 @@ class TestReversi < Minitest::Test
       00000000
       00000000
     BOARD
-    assert put_stone!(board, 'b5', BLACK_STONE)
+    assert put_stone!(board, 'b4', BLACK_STONE)
     assert_equal build_board(<<~BOARD), board
       00000000
       00020000


### PR DESCRIPTION
リバーシではなく「オセロ」で検索したら棋譜が見つかった。オセロの棋譜は1→8のようなので合わせる。