### PR TITLE
Rubocopの実行をプラクティスの要件に含まないこととする

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,0 @@
-inherit_gem:
-  rubocop-fjord:
-    - "config/rubocop.yml"

--- a/reversi.rb
+++ b/reversi.rb
@@ -12,7 +12,7 @@ class Reversi
     @current_stone = BLACK_STONE
   end
 
-  def run # rubocop:disable Metrics/MethodLength
+  def run
     loop do
       output(@board)
 


### PR DESCRIPTION
Rubocopを通すことを考えなくても良い、とするにあたって、関係する内容の削除が必要かと思います。
また、mergeの際は、FBC側の説明にある「rubocopがすべてパスしていることがわかる実行結果もあわせて提出してください。」という表現をカットする見込みです。