### PR TITLE
石の位置を示すコメントが誤っているため修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -12,8 +12,8 @@ module ReversiMethods
     board = Array.new(8) { Array.new(8, BLANK_CELL) }
     board[3][3] = WHITE_STONE # d4
     board[4][4] = WHITE_STONE # e5
-    board[3][4] = BLACK_STONE # d5
-    board[4][3] = BLACK_STONE # e4
+    board[3][4] = BLACK_STONE # e4
+    board[4][3] = BLACK_STONE # d5
     board
   end
 


### PR DESCRIPTION
https://github.com/fjordllc/bug_reversi/blob/main/README.md に記載されている通り、行が数字、列がアルファベットなのでコメントが一部逆転しているようです。修正しました。