### PR TITLE
fix : テストケースパスするように修正

### DIFF
--- a/lib/position.rb
+++ b/lib/position.rb
@@ -6,14 +6,14 @@ class Position
   ROW = %w[1 2 3 4 5 6 7 8].freeze
 
   DIRECTIONS = [
-    TOP_LEFT      = :top_left,
-    TOP           = :top,
-    TOP_RIGHT     = :top_right,
-    LEFT          = :left,
-    RIGHT         = :right,
-    BOTTOM_LEFT   = :bottom_left,
-    BOTTOM        = :bottom,
-    BOTTOM_RIGHT  = :bottom_right
+    TOP_LEFT = :top_left,
+    TOP = :top,
+    TOP_RIGHT = :top_right,
+    LEFT = :left,
+    RIGHT = :right,
+    BOTTOM_LEFT = :bottom_left,
+    BOTTOM = :bottom,
+    BOTTOM_RIGHT = :bottom_right
   ].freeze
 
   attr_accessor :row, :col
@@ -52,13 +52,13 @@ class Position
 
   def next_position(direction)
     case direction
-    when TOP_LEFT     then Position.new(row - 1, col - 1)
-    when TOP          then Position.new(row - 1, col)
-    when TOP_RIGHT    then Position.new(row - 1, col + 1)
-    when LEFT         then Position.new(row,     col - 1)
-    when RIGHT        then Position.new(row,     col + 1)
-    when BOTTOM_LEFT  then Position.new(row + 1, col - 1)
-    when BOTTOM       then Position.new(row + 1, col)
+    when TOP_LEFT then Position.new(row - 1, col - 1)
+    when TOP then Position.new(row - 1, col)
+    when TOP_RIGHT then Position.new(row - 1, col + 1)
+    when LEFT then Position.new(row, col - 1)
+    when RIGHT then Position.new(row, col + 1)
+    when BOTTOM_LEFT then Position.new(row + 1, col - 1)
+    when BOTTOM then Position.new(row + 1, col)
     when BOTTOM_RIGHT then Position.new(row + 1, col + 1)
     else raise 'Unknown direction'
     end

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -75,10 +75,7 @@ module ReversiMethods
   end
 
   def finished?(board)
-    is_filled_board = count_stone(board, BLACK_STONE) + count_stone(board, WHITE_STONE) == 64
-    is_not_placeable = !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
-
-    is_not_placeable || is_filled_board
+    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
   end
 
   def placeable?(board, attack_stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
@@ -63,6 +63,7 @@ module ReversiMethods
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
     return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)
@@ -74,7 +75,10 @@ module ReversiMethods
   end
 
   def finished?(board)
-    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
+    is_filled_board = count_stone(board, BLACK_STONE) + count_stone(board, WHITE_STONE) == 64
+    is_not_placeable = !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
+
+    is_not_placeable || is_filled_board
   end
 
   def placeable?(board, attack_stone_color)
@@ -86,6 +90,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
## 修正内容

### 1. `put_stone`：行と列を取り違えていた（`lib/reversi_methods.rb`）

`copied_board[pos.col][pos.row]` と添字が逆順だったため、ユーザーが指定したセルとは行・列が入れ替わったマスに石が置かれていた

### 2. `turn`：空マスをまたいで反転が成立してしまっていた（`lib/reversi_methods.rb`）

「対象マスが attack 色でなければ進む」という判定だけだったので、対象マスが空マス（`-`）でも再帰が継続し、最終的に attack 色まで到達すれば反転成立扱いになっていた。結果、初期盤面で黒が `b1` に置けてしまう（`b1 → c2(空) → d3(空) → e4(B)` で成立判定）。リバーシのルール上、相手の石で連続して挟まれている必要があるため、空マスに当たった時点でその方向は失敗とする。

### 3. `placeable?`：置けるマスがないとき `false` を返していなかった（`lib/reversi_methods.rb`）

`each_with_index` の戻り値（= `board` 自身、truthy）が暗黙的に返っていたため、両者ともに置けない盤面でも `placeable?` が真として評価されていた。これにより `finished?` が試合終了を検出できず、`run` の「詰みのためターンを切り替えます」も発火しなかった。


## テスト結果
```
% ruby test/reversi_methods_test.rb
Run options: --seed 57398

# Running:

.........

Finished in 0.010573s, 851.2248 runs/s, 1702.4496 assertions/s.

9 runs, 18 assertions, 0 failures, 0 errors, 0 skips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ゲームボード上への石の配置ロジックを修正しました。
  * ゲーム終了条件を改善し、盤面が満杯になった場合も正しく判定するようになりました。

* **改善**
  * ゲームの進行がより安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->